### PR TITLE
Update AboutUs page with RandomNerd01's info

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -19,15 +19,14 @@ You can reach us at the email `seer[at]comp.nus.edu.sg`
 
 * Role: Project Advisor
 
-### Jane Doe
+### Lim Sui Ron
 
-<img src="images/johndoe.png" width="200px">
+<img src="images/randomnerd01.png" width="200px">
 
-[[github](http://github.com/johndoe)]
-[[portfolio](team/johndoe.md)]
+[[github](http://github.com/randomnerd01)]
 
-* Role: Team Lead
-* Responsibilities: UI
+* Role: Developer
+* Responsibilities: Data
 
 ### Johnny Doe
 


### PR DESCRIPTION
Update AboutUs page with my profile information including photo link, GitHub/portfolio links, role, and responsibilities.

## Changes
- Added my profile section to `docs/AboutUs.md`
- Included image reference to `randomnerd01.png`
- Added GitHub link
- Specified role and responsibilities

Closes Issue #17