### PR TITLE
Update AboutUs page with tokitobashi1's info

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -29,11 +29,11 @@ You can reach us at the email `seer[at]comp.nus.edu.sg`
 * Role: Team Lead
 * Responsibilities: UI
 
-### Johnny Doe
+### Lim Sui Hao
 
-<img src="images/johndoe.png" width="200px">
+<img src="images/tokitobashi1.png" width="200px">
 
-[[github](http://github.com/johndoe)] [[portfolio](team/johndoe.md)]
+[[github](http://github.com/tokitobashi1)] 
 
 * Role: Developer
 * Responsibilities: Data


### PR DESCRIPTION
Update AboutUs page with my profile information including photo link, GitHub/portfolio links, role, and responsibilities.

## Changes
- Added my profile section to `docs/AboutUs.md`
- Included image reference to `tokitobashi1.png`
- Added GitHub link
- Specified role and responsibilities

## Linked Issue
- Fixes #21 